### PR TITLE
🤔  Drag and Drop in mobile

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -13,9 +13,12 @@
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm-community/list-extra": "8.7.0",
-            "elm-community/random-extra": "3.2.0"
+            "elm-community/random-extra": "3.2.0",
+            "mpizenberg/elm-pointer-events": "4.0.2"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
@@ -24,8 +27,6 @@
         "direct": {
             "elm-explorations/test": "2.1.0"
         },
-        "indirect": {
-            "elm/bytes": "1.0.8"
-        }
+        "indirect": {}
     }
 }

--- a/src/Main.elm.d.ts
+++ b/src/Main.elm.d.ts
@@ -14,10 +14,22 @@ export namespace Elm {
       gitRef: string;
     }
 
+    interface DragStartData {
+      effectAllowed: 'none' | 'copy' | 'copyLink' | 'copyMove' | 'link' | 'linkMove' | 'move' | 'all' | 'uninitialized';
+      event: DragEvent;
+    }
+
+    interface DragOverData {
+      dropEffect: 'none' | 'copy' | 'link' | 'move';
+      event: DragEvent;
+    }
+
     interface Ports {
       setStorage: Subscribe<object>;
       playSound: Subscribe<string>;
       notify: Subscribe<string>;
+      dragstart: Subscribe<DragStartData>;
+      dragover: Subscribe<DragOverData>;
     }
 
     interface Subscribe<T> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,14 @@ import { Elm } from './Main.elm';
 
 declare const APP_COMMIT_REF: string;
 
+// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions
+function assertIsDefined<T>(val: T): asserts val is NonNullable<T> {
+  if (val === undefined || val === null) {
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    throw new Error(`Expected 'val' to be defined, but received ${val}`);
+  }
+}
+
 const isSupportedNotification = 'Notification' in window;
 
 const storedData = localStorage.getItem('mobu-model');
@@ -48,4 +56,18 @@ app.ports.notify.subscribe((message: string) => {
       });
       break;
   }
+});
+
+app.ports.dragstart.subscribe((data) => {
+  const { effectAllowed, event: { dataTransfer } } = data;
+  debugger;
+  assertIsDefined(dataTransfer);
+  dataTransfer.setData('text/plain', ''); // needed
+  dataTransfer.effectAllowed = effectAllowed;
+});
+
+app.ports.dragover.subscribe((data) => {
+  const { dropEffect, event: { dataTransfer } } = data;
+  assertIsDefined(dataTransfer);
+  dataTransfer.dropEffect = dropEffect;
 });


### PR DESCRIPTION
https://github.com/mobu-of-the-world/emobu/pull/216 made dnd. However it does not work in mobile view since avoiding to touch native Drag and Drop API as https://github.com/mobu-of-the-world/mobu/pull/430

Fixing this sounds need many changes. I'm pending.

https://discourse.elm-lang.org/t/package-for-drag-and-drop-for-sortable-lists-with-mouse-events/3125 https://annaghi.github.io/dnd-list/ has same issue

https://github.com/mpizenberg/elm-pointer-events

ref: https://github.com/mobu-of-the-world/emobu/issues/209