### PR TITLE
Integrate playwright with Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,16 @@
               dprint
               nodejs_20
               typos
+
+              # https://github.com/NixOS/nixpkgs/issues/215450#issuecomment-1526251592
+              playwright
+              playwright-driver.browsers
             ];
+
+            shellHook = ''
+              export PLAYWRIGHT_BROWSERS_PATH=${playwright-driver.browsers}
+              export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true
+            '';
           };
       });
 }


### PR DESCRIPTION
To prevent issues as https://github.com/mobu-of-the-world/emobu/issues/382

* Playwright looks good and I want to try it to check the difference from Cypress.
* Candidates are cypress, playwright, testcafe
* Both cypress and playwright are not exclusive in npm dependencies, they need OS dependencies.
* So I want to provide a nix environment.

https://github.com/NixOS/nixpkgs/issues/215450#issuecomment-1526251592
https://github.com/NixOS/nixpkgs/issues/217693
https://github.com/NixOS/nixpkgs/pull/227071
https://github.com/microsoft/playwright/issues/5501#issuecomment-1295693426
https://github.com/pbek/playwright-example